### PR TITLE
Markdown fix and formatting

### DIFF
--- a/content/dev/packaging/packaging-rules/_index.md
+++ b/content/dev/packaging/packaging-rules/_index.md
@@ -74,22 +74,22 @@ configure --prefix=/usr --libdir=/usr/lib${LIBDIRSUFFIX} --localstatedir=/var --
 
 where `$LIBDIRSUFFIX` should be empty for x86 packages and set to "64" for x86_64 packages.
 This also means that: 
-* Packages are not allowed to install files in "/opt" and "/usr/local" by any means.
-* "/usr" is the install path prefix
-* log files must be installed in the directory "/var"
-* configuration files must be installed in the directory "/etc"
-* man pages must be placed in "/usr/man"
+* Packages are not allowed to install files in "**/opt**" and "**/usr/local**" by any means.
+* "**/usr**" is the install path prefix
+* log files must be installed in the directory "**/var**"
+* configuration files must be installed in the directory "**/etc**"
+* man pages must be placed in "**/usr/man**"
 
 All binaries and system libraries must be stripped of debugging symbols.
 
 Man pages and Info files must be gziped.
 
-Files installed to the directory "/usr/doc" must not have group/world writeable
+Files installed to the directory "**/usr/doc**" must not have group/world writeable
 permissions.
 
 All X application packages which are supposed to appear in the application menu
-shall install appropriate "packagename.desktop" files in the
-"/usr/share/applications" directory.
+shall install appropriate "**packagename.desktop**" files in the
+"**/usr/share/applications**" directory.
 
 All icons are to be installed in the
 **/usr/share/icons/hicolor/scalable/apps/** or

--- a/content/dev/packaging/uid-gid/_index.md
+++ b/content/dev/packaging/uid-gid/_index.md
@@ -6,7 +6,7 @@ linktitle: "slkbuild UIDs/GIDs"
 ## Recommended UID/GIDs 
 
 The recommended UID/GIDs for use with SLKBUILD scripts are the same as
-[the ones for slackbuilds.org](https://slackbuilds.org/uid_gid.txt Defaults Slackware UID/GIDs)
+[the ones for slackbuilds.org](https://slackbuilds.org/uid_gid.txt) (Default Slackware UID/GIDs)
 in order to avoid conflicts with packages build from SBo.
 
 ## Extra 


### PR DESCRIPTION
This patch set contains:
- Bold formatting to some directory entries;
- A fix for an url entry with extra data in parenthesis;

Changes were tested with Hugo v0.123.8.